### PR TITLE
Add note on non-English word tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It’s important to remember that you pay by the token for responses. This means
 
 ### 1.3: Average tokens per word
 
-LLMs operate on tokens. Tokens are words or sub-parts of words, so “eating” might be broken into two tokens “eat” and “ing”. A 750 word document will be about 1000 tokens. 
+LLMs operate on tokens. Tokens are words or sub-parts of words, so “eating” might be broken into two tokens “eat” and “ing”. A 750 word document in English will be about 1000 tokens. For languages other than English, the tokens per word increases depending on their commonality in OpenAI's training corpus.
 
 Knowing this ratio is important because most billing is done in tokens, and the LLM’s context window size is also defined in tokens. 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It’s important to remember that you pay by the token for responses. This means
 
 ### 1.3: Average tokens per word
 
-LLMs operate on tokens. Tokens are words or sub-parts of words, so “eating” might be broken into two tokens “eat” and “ing”. A 750 word document in English will be about 1000 tokens. For languages other than English, the tokens per word increases depending on their commonality in OpenAI's training corpus.
+LLMs operate on tokens. Tokens are words or sub-parts of words, so “eating” might be broken into two tokens “eat” and “ing”. A 750 word document in English will be about 1000 tokens. For languages other than English, the tokens per word increases depending on their commonality in the LLM's embedding corpus.
 
 Knowing this ratio is important because most billing is done in tokens, and the LLM’s context window size is also defined in tokens. 
 


### PR DESCRIPTION
OpenAI reference https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them

> How words are split into tokens is also language-dependent. For example ‘Cómo estás’ (‘How are you’ in Spanish) contains 5 tokens (for 10 chars). The higher token-to-char ratio can make it more expensive to implement the API for languages other than English.

Generic BPE tokenized LLMs https://medium.com/@pierre_guillou/byte-level-bpe-an-universal-tokenizer-but-aff932332ffe
> As we can see, even if a GPT2TokenizerFast trained with an English corpus can tokenize any text in any language, it was optimized for English: the number of generated tokens is lower for an English text than for the same text in another language with an equivalent number of words.
