### PR TITLE
Update README.md GPT-4 vs GPT-3.5 Turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Prices are of course subject to change, but given how expensive LLMs are to oper
 
 ### ~50:1 -- Cost Ratio of GPT-4 to GPT-3.5 Turbo[^3] 
 
-What this means is that for many practical applications, it’s much better to use GPT-4 for things like generation and then use that data to fine tune a smaller model. It is roughly 50 times cheaper to use GPT-3.5-Turbo than GPT-4 (the “roughly” is because GPT-4 charges differently for the prompt and the generated output)  – so you really need to check on how far you can get with GPT-3.5-Turbo. GPT-3.5-Turbo is more than enough for tasks like summarization for example. 
+What this means is that for many practical applications, it’s much better to use GPT-3.5 Turbo for things like generation and then use that data to fine tune a smaller model. It is roughly 50 times cheaper to use GPT-3.5-Turbo than GPT-4 (the “roughly” is because GPT-4 charges differently for the prompt and the generated output)  – so you really need to check on how far you can get with GPT-3.5-Turbo. GPT-3.5-Turbo is more than enough for tasks like summarization for example. 
 
 
 ### 5:1 -- Cost Ratio of generation of text using GPT-3.5-Turbo vs OpenAI embedding 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Prices are of course subject to change, but given how expensive LLMs are to oper
 
 ### ~50:1 -- Cost Ratio of GPT-4 to GPT-3.5 Turbo[^3] 
 
-What this means is that for many practical applications, it’s much better to use GPT-3.5 Turbo for things like generation and then use that data to fine tune a smaller model. It is roughly 50 times cheaper to use GPT-3.5-Turbo than GPT-4 (the “roughly” is because GPT-4 charges differently for the prompt and the generated output)  – so you really need to check on how far you can get with GPT-3.5-Turbo. GPT-3.5-Turbo is more than enough for tasks like summarization for example. 
+What this means is that for many practical applications, it’s much better to use GPT-4 for things like generating high quality fine tuning data, or for automated evaluation of other models -- things you might only do once instead of it living in the middle of your inference cycle. It is roughly 50 times cheaper to use GPT-3.5-Turbo than GPT-4 (the “roughly” is because GPT-4 charges differently for the prompt and the generated output)  – so you really need to check on how far you can get with GPT-3.5-Turbo. GPT-3.5-Turbo is more than enough for tasks like summarization for example. 
 
 
 ### 5:1 -- Cost Ratio of generation of text using GPT-3.5-Turbo vs OpenAI embedding 


### PR DESCRIPTION
GPT-4 is listed as being 50x as expensive as GPT-3.5 Turbo, so GPT-3.5 Turbo should be a better choice to generate data if the performance works out. The README says in the first sentence of the paragraph the contrary in that one should use GPT-4 to generate data.